### PR TITLE
fix: wgpu rendering issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,10 @@ markdown = "0.3.0"
 [dependencies.libcosmic]
 git = "https://github.com/pop-os/libcosmic"
 default-features = false
-features = ["applet", "tokio", "wayland", "wgpu"]
+features = ["applet", "tokio", "wayland"]
+
+[features]
+wgpu = ["libcosmic/wgpu"]
 
 [dependencies.cosmic-syntax-theme]
 git = "https://github.com/pop-os/cosmic-syntax-theme.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ default-features = false
 features = ["applet", "tokio", "wayland"]
 
 [features]
+default = ["wgpu"]
 wgpu = ["libcosmic/wgpu"]
 
 [dependencies.cosmic-syntax-theme]

--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@
 
 Before using this applet, you must have Ollama installed on your system. To do this, run this in your terminal:
 
-`curl -fsSL https://ollama.com/install.sh | sh`
+```sh
+curl -fsSL https://ollama.com/install.sh | sh
+```
 
 Source: [Ollama Github](https://github.com/ollama/ollama?tab=readme-ov-file#linux)
 
 After installing Ollama. Pull some models, you would like to use with chat, for example
 
-`ollama pull llama3`
+```sh
+ollama pull llama3
+```
 
 More models you can find in library: https://ollama.com/library
 
@@ -25,26 +29,44 @@ Clone the repository, and use [just](https://github.com/casey/just)
 
 If you don't have `just` installed, it is available in PopOS repository, so you can install it with `apt`
 
-`sudo apt install just`
+```sh
+sudo apt install just
+```
 
 Now you can clone repo and install applet.
 
-`git clone https://github.com/elevenhsoft/cosmic-ext-applet-ollama.git`
-
-`cd cosmic-ext-applet-ollama`
+```sh
+git clone https://github.com/elevenhsoft/cosmic-ext-applet-ollama.git
+cd cosmic-ext-applet-ollama
+```
 
 ### Building
 
 Run just:
 
-`just`
+```sh
+just
+```
 
 ### Installing
 
-`sudo just install`
+```sh
+sudo just install
+```
 
 Done
 
 From now, you will be able to add applet to your desktop panel/dock and chat with different models in real time :)
 
-Cheers!
+Cheers!  
+
+## Known wgpu issue
+
+There are currently some rendering issues with the `wgpu` libcosmic features in some (older?) gpus.
+This doesn't affect Ollama, only the applet.
+If you are affected by this, you can build and install it with this feature disabled:
+
+```sh
+just build-no-wgpu
+sudo just install
+```

--- a/justfile
+++ b/justfile
@@ -25,7 +25,10 @@ build-debug *args:
     cargo build {{args}}
 
 # Compiles with release profile
-build-release *args: (build-debug '--release' args)
+build-release *args: (build-debug '--release --features wgpu' args)
+
+# Compiles with release profile with wgpu disabled
+build-no-wpgu *args: (build-debug '--release' args)
 
 # Compile with a vendored tarball
 build-vendored *args: vendor-extract (build-release '--frozen --offline' args)

--- a/justfile
+++ b/justfile
@@ -25,10 +25,10 @@ build-debug *args:
     cargo build {{args}}
 
 # Compiles with release profile
-build-release *args: (build-debug '--release --features wgpu' args)
+build-release *args: (build-debug '--release' args)
 
 # Compiles with release profile with wgpu disabled
-build-no-wpgu *args: (build-debug '--release' args)
+build-no-wpgu *args: (build-debug '--release --no-default-features' args)
 
 # Compile with a vendored tarball
 build-vendored *args: vendor-extract (build-release '--frozen --offline' args)


### PR DESCRIPTION
The `wgpu` feature causes some rendering bugs in some older gpus:

![image](https://github.com/user-attachments/assets/45c82f64-28f3-4b46-ac3a-0f25f2be6c99)
